### PR TITLE
fix: correct link to slack pricing site

### DIFF
--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -31,7 +31,7 @@
           <li>mobile apps</li>
           <li><a href="https://slack.com/integrations">integrations</a> with services such as Google Docs, Dropbox, email, Google calendar, Trello, etc.</li>
         </ul>
-        <p>Their <a href="https://cobot.slack.com/pricing">free account</a> offers unlimited members. The only limits are on number of file uploads, 10 service integrations, and 10k messages saved in the message archive.</p>
+        <p>Their <a href="https://slack.com/pricing">free account</a> offers unlimited members. The only limits are on number of file uploads, 10 service integrations, and 10k messages saved in the message archive.</p>
         <div class="media">
           <div class="media__figure">
             <%= image_tag 'zapier.svg', width: 50, style: 'display: inline' %>


### PR DESCRIPTION
Without that, you need to be signed in to the cobot slack to see the pricing of Slack.

(Just stumbled over that while working on the other integration)