### PR TITLE
add retire message

### DIFF
--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,52 +3,32 @@
     <div class="grid grid-center grid--gutters--huge grid--full tablet-grid--1of2">
       <div class="grid-cell">
         <h2 class="f2 f1-ns mt2 measure">Integrate Cobot with Slack</h2>
-        <p class="mb4 measure">This <a href="http://cobot.me/addons">add-on</a> connects your space’s Cobot account with your <a href="http://slack.com">slack.com</a> account. This means that new members who are added through Cobot will automatically be invited to join your Slack team, so you don’t have to add them manually.</p>
-
-        <p>Now that they have been added to your Slack channel, you have a communication point for everyone in your space to:</p>
+        <p class="mb4 measure" style="text-decoration: line-through">This <a href="http://cobot.me/addons">add-on</a> connects your space’s Cobot account with your <a href="http://slack.com">slack.com</a> account. This means that new members who are added through Cobot will automatically be invited to join your Slack team, so you don’t have to add them manually.</p>
+        <p class="mb4 measure">
+          Slack has decided that inviting users is now an Enterprise-only feature.
+          This means this add-on will stop working in May 2020.
+        </p>
+        <p>
+          After the app stops working,
+          we recommend that you
+        </p>
         <ul>
-          <li>Talk about what is happening in the space</li>
-          <li>Post events</li>
-          <li>Welcome new members</li>
-          <li>Announce packages delivered to the space</li>
-        </ul>
-        <p>The sky is the limit!</p>
-        <p><%= link_to 'Get Started', sign_in_path, class: 'btn btn--full btn--hl btn--biggest' %></p>
+          <li><a href="https://slack.com/intl/en-de/help/articles/201330256-Invite-new-members-to-your-workspace?eu_nc=1#share-an-invite-link" target="_blank">generate an invite link</a></li>
+          <li>
+            add the invite link to your <a href="https://www.cobot.me/en/support/guides/plans-space-access/adding-membership-plans#messages">welcome message</a> or
+            <a href="https://www.cobot.me/en/support/guides/the-basics/customization#emails">membership confirmation email</a>
+          </li>
+        </p>
+
+        <p>
+          <%= link_to 'Log in',
+            sign_in_path,
+            class: 'btn btn--full btn--primary' %> to manage existing integrations.</p>
       </div>
 
       <div class="grid-cell">
         <div class="bg--white shadow-cobot pa5 integration-logo__box">
           <%= image_pack_tag 'slack.svg', class:'w-100 mv4' %>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-<div class="cb-section cb-section--padded">
-  <div class="cb-container">
-    <div class="measure-wide">
-      <div class="grid-cell">
-        <h3 class="f3 f2-ns">What is Slack?</h3>
-        <p>
-          <a href="http://slack.com">Slack</a> is arguably the best team communication application there is, used by companies around the world, including Cobot. It allows you to manage communication between team members and various online accounts in one application.
-        </p>
-        <p>It offers:</p>
-        <ul>
-          <li>chat rooms and private messaging</li>
-          <li>drag&drop file sharing</li>
-          <li>emojis 😀</li>
-          <li>full-text search & archiving</li>
-          <li>mobile apps</li>
-          <li><a href="https://slack.com/integrations">integrations</a> with services such as Google Docs, Dropbox, email, Google calendar, Trello, etc.</li>
-        </ul>
-        <p>Their <a href="https://slack.com/pricing">free account</a> offers unlimited members. The only limits are on number of file uploads, 10 service integrations, and 10k messages saved in the message archive.</p>
-        <div class="media">
-          <div class="media__figure">
-            <%= image_pack_tag 'zapier.svg', width: 50, style: 'display: inline' %>
-          </div>
-          <div class="media__body">
-            You can also use our <a href="http://blog.cobot.me/post/111166081512/cobot-now-connects-with-zapier-were-looking-for">beta Zapier integration</a> to deliver custom information from Cobot’s API directly to your Slack channel.
-          </div>
         </div>
       </div>
     </div>

--- a/app/views/welcome/show.html.erb
+++ b/app/views/welcome/show.html.erb
@@ -3,27 +3,29 @@
     <div class="grid grid-center grid--gutters--huge grid--full tablet-grid--1of2">
       <div class="grid-cell">
         <h2 class="f2 f1-ns mt2 measure">Integrate Cobot with Slack</h2>
-        <p class="mb4 measure" style="text-decoration: line-through">This <a href="http://cobot.me/addons">add-on</a> connects your space’s Cobot account with your <a href="http://slack.com">slack.com</a> account. This means that new members who are added through Cobot will automatically be invited to join your Slack team, so you don’t have to add them manually.</p>
+        <p class="mb4 measure" style="text-decoration: line-through">This <a href="http://cobot.me/addons">add-on</a> connects your space’s Cobot account with your <a href="http://slack.com">slack.com</a> account. New Cobot members are automatically invited to join your Slack team, so you don’t have to add them manually.</p>
         <p class="mb4 measure">
-          Slack has decided that inviting users is now an Enterprise-only feature.
-          This means this add-on will stop working in May 2020.
+          Slack has decided that inviting users is now an Enterprise-only feature. This means this add-on will stop working in May 2020.
         </p>
         <p>
-          After the app stops working,
-          we recommend that you
+          After the app stops working, you can still automate your members joining your Slack team. We recommend that you
         </p>
         <ul>
-          <li><a href="https://slack.com/intl/en-de/help/articles/201330256-Invite-new-members-to-your-workspace?eu_nc=1#share-an-invite-link" target="_blank">generate an invite link</a></li>
           <li>
-            add the invite link to your <a href="https://www.cobot.me/en/support/guides/plans-space-access/adding-membership-plans#messages">welcome message</a> or
-            <a href="https://www.cobot.me/en/support/guides/the-basics/customization#emails">membership confirmation email</a>
+            <a href="https://slack.com/intl/en-de/help/articles/201330256-Invite-new-members-to-your-workspace?eu_nc=1#share-an-invite-link" target="_blank">generate an invite link in Slack</a> and
           </li>
-        </p>
+          <li>
+            add this invite link to your <a href="https://www.cobot.me/en/support/guides/plans-space-access/adding-membership-plans#messages">Cobot welcome message</a> or
+            <a href="https://www.cobot.me/en/support/guides/the-basics/customization#emails">Cobot membership confirmation email</a>
+          </li>
+        </ul>
 
         <p>
+          In order to manage your existing integrations, please log in.
           <%= link_to 'Log in',
             sign_in_path,
-            class: 'btn btn--full btn--primary' %> to manage existing integrations.</p>
+            class: 'btn btn--full btn--primary btn--round' %>
+        </p>
       </div>
 
       <div class="grid-cell">

--- a/spec/support/login_helpers.rb
+++ b/spec/support/login_helpers.rb
@@ -6,7 +6,7 @@ module LoginHelpers
     ]
     OmniAuth.config.mock_auth[:cobot]['credentials']['token'] = access_token
     visit root_path
-    click_on 'Get Started'
+    click_on 'Log in'
     click_on 'Log in'
     Space.where(subdomain: subdomain).first
   end


### PR DESCRIPTION
Slack is making the invite feature Enterprise-only, which means this app will stop working.

<img width="1108" alt="image" src="https://user-images.githubusercontent.com/2173/77932599-0f03ba80-72ae-11ea-93df-8fa9d90da723.png">
